### PR TITLE
Anchoring system

### DIFF
--- a/src/contents/ui/OverlayTiler.qml
+++ b/src/contents/ui/OverlayTiler.qml
@@ -85,11 +85,32 @@ PlasmaCore.Dialog {
                 };
             } else {
                 let layout = tileRepeater.model[activeIndex];
+                let width = layout.w / 100 * clientArea.width;
+                let height = layout.h / 100 * clientArea.height;
+                let x = clientArea.x + layout.x / 100 * clientArea.width;
+                let y = clientArea.y + layout.y / 100 * clientArea.height;
+                
+                // Apply anchor
+                let anchorX = layout.anchorX || 'L';
+                let anchorY = layout.anchorY || 'T';
+                
+                if (anchorX === 'C') {
+                    x -= width / 2;
+                } else if (anchorX === 'R') {
+                    x -= width;
+                }
+                
+                if (anchorY === 'C') {
+                    y -= height / 2;
+                } else if (anchorY === 'B') {
+                    y -= height;
+                }
+                
                 return {
-                    x: clientArea.x + layout.x / 100 * clientArea.width,
-                    y: clientArea.y + layout.y / 100 * clientArea.height,
-                    width: layout.w / 100 * clientArea.width,
-                    height: layout.h / 100 * clientArea.height
+                    x: x,
+                    y: y,
+                    width: width,
+                    height: height
                 };
             }
         }

--- a/src/contents/ui/PopupTiler.qml
+++ b/src/contents/ui/PopupTiler.qml
@@ -154,11 +154,32 @@ PlasmaCore.Dialog {
             };
         } else if (activeLayoutIndex >= 0 && activeTileIndex >= 0) {
             let layout = layoutRepeater.model[activeLayoutIndex].tiles[activeTileIndex];
+            let width = layout.w == undefined ? layout.pxW : layout.w / 100 * clientArea.width;
+            let height = layout.h == undefined ? layout.pxH : layout.h / 100 * clientArea.height;
+            let x = clientArea.x + (layout.x == undefined ? layout.pxX : layout.x / 100 * clientArea.width);
+            let y = clientArea.y + (layout.y == undefined ? layout.pxY : layout.y / 100 * clientArea.height);
+            
+            // Apply anchor
+            let anchorX = layout.anchorX || 'L';
+            let anchorY = layout.anchorY || 'T';
+            
+            if (anchorX === 'C') {
+                x -= width / 2;
+            } else if (anchorX === 'R') {
+                x -= width;
+            }
+            
+            if (anchorY === 'C') {
+                y -= height / 2;
+            } else if (anchorY === 'B') {
+                y -= height;
+            }
+            
             return {
-                x: clientArea.x + (layout.x == undefined ? layout.pxX : layout.x / 100 * clientArea.width),
-                y: clientArea.y + (layout.y == undefined ? layout.pxY : layout.y / 100 * clientArea.height),
-                width: layout.w == undefined ? layout.pxW : layout.w / 100 * clientArea.width,
-                height: layout.h == undefined ? layout.pxH : layout.h / 100 * clientArea.height
+                x: x,
+                y: y,
+                width: width,
+                height: height
             };
         }
         return null;
@@ -198,10 +219,31 @@ PlasmaCore.Dialog {
                     break;
                 default:
                     let layout = layoutRepeater.model[activeLayoutIndex].tiles[activeTileIndex];
-                    popupDropHintX = layout.x == undefined ? layout.pxX : layout.x / 100 * clientArea.width;
-                    popupDropHintY = layout.y == undefined ? layout.pxY : layout.y / 100 * clientArea.height;
-                    popupDropHintWidth = layout.w == undefined ? layout.pxW : layout.w / 100 * clientArea.width;
-                    popupDropHintHeight = layout.h == undefined ? layout.pxH : layout.h / 100 * clientArea.height;
+                    let width = layout.w == undefined ? layout.pxW : layout.w / 100 * clientArea.width;
+                    let height = layout.h == undefined ? layout.pxH : layout.h / 100 * clientArea.height;
+                    let x = layout.x == undefined ? layout.pxX : layout.x / 100 * clientArea.width;
+                    let y = layout.y == undefined ? layout.pxY : layout.y / 100 * clientArea.height;
+                    
+                    // Apply anchor
+                    let anchorX = layout.anchorX || 'L';
+                    let anchorY = layout.anchorY || 'T';
+                    
+                    if (anchorX === 'C') {
+                        x -= width / 2;
+                    } else if (anchorX === 'R') {
+                        x -= width;
+                    }
+                    
+                    if (anchorY === 'C') {
+                        y -= height / 2;
+                    } else if (anchorY === 'B') {
+                        y -= height;
+                    }
+                    
+                    popupDropHintX = x;
+                    popupDropHintY = y;
+                    popupDropHintWidth = width;
+                    popupDropHintHeight = height;
                     showPopupDropHint = true;
                     return; // Force return to avoid hiding popup
             }
@@ -336,8 +378,22 @@ PlasmaCore.Dialog {
                                 property bool tileActive: activeTileIndex == index
                                 property bool tileDisabled: modelData.d ? true : false
 
-                                x: (modelData.x == undefined ? modelData.pxX / clientArea.width : modelData.x / 100) * (tiles.width - borderOffset * 2) + borderOffset
-                                y: (modelData.y == undefined ? modelData.pxY / clientArea.height : modelData.y / 100) * (tiles.height - borderOffset * 2) + borderOffset
+                                x: {
+                                    let width = (modelData.w == undefined ? modelData.pxW / clientArea.width : modelData.w / 100) * (tiles.width - borderOffset * 2);
+                                    let x = (modelData.x == undefined ? modelData.pxX / clientArea.width : modelData.x / 100) * (tiles.width - borderOffset * 2) + borderOffset;
+                                    let anchorX = modelData.anchorX || 'L';
+                                    if (anchorX === 'C') x -= width / 2;
+                                    else if (anchorX === 'R') x -= width;
+                                    return x;
+                                }
+                                y: {
+                                    let height = (modelData.h == undefined ? modelData.pxH / clientArea.height : modelData.h / 100) * (tiles.height - borderOffset * 2);
+                                    let y = (modelData.y == undefined ? modelData.pxY / clientArea.height : modelData.y / 100) * (tiles.height - borderOffset * 2) + borderOffset;
+                                    let anchorY = modelData.anchorY || 'T';
+                                    if (anchorY === 'C') y -= height / 2;
+                                    else if (anchorY === 'B') y -= height;
+                                    return y;
+                                }
                                 width: (modelData.w == undefined ? modelData.pxW / clientArea.width : modelData.w / 100) * (tiles.width - borderOffset * 2)
                                 height: (modelData.h == undefined ? modelData.pxH / clientArea.height : modelData.h / 100) * (tiles.height - borderOffset * 2)
 

--- a/src/contents/ui/config.ui
+++ b/src/contents/ui/config.ui
@@ -1077,8 +1077,22 @@
           <item>
            <widget class="QLabel" name="label_popupLayoutExplanation">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the layouts for the Popup mode - one layout per line.&lt;br/&gt;&lt;br/&gt;Valid format is either a grid [XxY] (example 4x2) or [X,Y,Width,Height]. Any of the values can be in percent (recommended) or pixels (using px suffix - not recommended).&lt;br/&gt;&lt;br/&gt;Example 0,0,100,100 for a full screen tile equal to 1x1 or 20,10,400px,200px for a 400 pixel wide, 200 pixel high tile placed at 20% screen width and 10% screen height.
-&lt;br/&gt;&lt;br/&gt; The layout can be made of multiple grids and/or cells separated by a + (example 0,0,50,100+50,0,50,100 which is equal to a 2x1).&lt;br/&gt;&lt;br/&gt;You can also use one of special layouts: SPECIAL_FILL, SPECIAL_SPLIT_VERTICAL, SPECIAL_SPLIT_HORIZONTAL, SPECIAL_MAXIMIZE, SPECIAL_MINIMIZE, SPECIAL_FULLSCREEN, SPECIAL_KEEP_ABOVE, SPECIAL_KEEP_BELOW, SPECIAL_NO_TITLEBAR_AND_FRAME, SPECIAL_CLOSE and SPECIAL_EMPTY.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>Set the layouts for the Popup mode - one layout per line.
+
+Valid format is either a grid [XxY] (example 4x2) or [X,Y,Width,Height]. Any of the values can be in percent (recommended) or pixels (using px suffix - not recommended).
+
+You can optionally prefix X with L/C/R (Left/Center/Right) and Y with T/C/B (Top/Center/Bottom) to control which part of the window is positioned. Default is L (Left) and T (Top).
+
+Examples:
+- 0,0,100,100 - Full screen tile (top-left corner at 0,0)
+- C50,C50,50,50 - Window center at screen center, resized to 50% screen width and 50% screen height
+- C50,C50,1920px,1080px - Window center at screen center, resized to 1920x1080 (useful for webdevs with ultrawides)
+- R100,B100,50,50 - Window bottom-right at screen bottom-right, resized to 50% screen width and 50% screen height
+- 20,10,400px,200px - 400x200px tile at 20% width, 10% height
+
+The layout can be made of multiple grids and/or cells separated by a + (example 0,0,50,100+50,0,50,100 which is equal to a 2x1).
+
+You can also use one of special layouts: SPECIAL_FILL, SPECIAL_SPLIT_VERTICAL, SPECIAL_SPLIT_HORIZONTAL, SPECIAL_MAXIMIZE, SPECIAL_MINIMIZE, SPECIAL_FULLSCREEN, SPECIAL_KEEP_ABOVE, SPECIAL_KEEP_BELOW, SPECIAL_NO_TITLEBAR_AND_FRAME, SPECIAL_CLOSE and SPECIAL_EMPTY.</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -1130,8 +1144,22 @@
           <item>
            <widget class="QLabel" name="label_allPopupLayoutsExplanation">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set all the layouts for the Popup mode - one layout per line.&lt;br/&gt;&lt;br/&gt;Valid format is either a grid [XxY] (example 4x2) or [X,Y,Width,Height]. Any of the values can be in percent (recommended) or pixels (using px suffix - not recommended).&lt;br/&gt;&lt;br/&gt;Example 0,0,100,100 for a full screen tile equal to 1x1 or 20,10,400px,200px for a 400 pixel wide, 200 pixel high tile placed at 20% screen width and 10% screen height.
-&lt;br/&gt;&lt;br/&gt; The layout can be made of multiple grids and/or cells separated by a + (example 0,0,50,100+50,0,50,100 which is equal to a 2x1).&lt;br/&gt;&lt;br/&gt;You can also use one of special layouts: SPECIAL_FILL, SPECIAL_SPLIT_VERTICAL, SPECIAL_SPLIT_HORIZONTAL, SPECIAL_MAXIMIZE, SPECIAL_MINIMIZE, SPECIAL_FULLSCREEN, SPECIAL_KEEP_ABOVE, SPECIAL_KEEP_BELOW, SPECIAL_NO_TITLEBAR_AND_FRAME, SPECIAL_CLOSE and SPECIAL_EMPTY.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>Set all the layouts for the Popup mode - one layout per line.
+
+Valid format is either a grid [XxY] (example 4x2) or [X,Y,Width,Height]. Any of the values can be in percent (recommended) or pixels (using px suffix - not recommended).
+
+You can optionally prefix X with L/C/R (Left/Center/Right) and Y with T/C/B (Top/Center/Bottom) to control which part of the window is positioned. Default is L (Left) and T (Top).
+
+Examples:
+- 0,0,100,100 - Full screen tile (top-left corner at 0,0)
+- C50,C50,50,50 - Window center at screen center, resized to 50% screen width and 50% screen height
+- C50,C50,1920px,1080px - Window center at screen center, resized to 1920x1080 (useful for webdevs with ultrawides)
+- R100,B100,50,50 - Window bottom-right at screen bottom-right, resized to 50% screen width and 50% screen height
+- 20,10,400px,200px - 400x200px tile at 20% width, 10% height
+
+The layout can be made of multiple grids and/or cells separated by a + (example 0,0,50,100+50,0,50,100 which is equal to a 2x1).
+
+You can also use one of special layouts: SPECIAL_FILL, SPECIAL_SPLIT_VERTICAL, SPECIAL_SPLIT_HORIZONTAL, SPECIAL_MAXIMIZE, SPECIAL_MINIMIZE, SPECIAL_FULLSCREEN, SPECIAL_KEEP_ABOVE, SPECIAL_KEEP_BELOW, SPECIAL_NO_TITLEBAR_AND_FRAME, SPECIAL_CLOSE and SPECIAL_EMPTY.</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -303,28 +303,43 @@ SPECIAL_FILL-Fill
                             }
                         }
                     } else if (coordinates.length == 4) {
-                        // x,y,w,h
+                        // x,y,w,h with optional anchor prefixes (L/C/R for x, T/C/B for y)
                         let x, pxX, y, pxY, w, pxW, h, pxH;
+                        let anchorX = 'L'; // Default: Left
+                        let anchorY = 'T'; // Default: Top
                         isValid = true;
-                        if (coordinates[0].endsWith('px')) {
-                            pxX = parseInt(coordinates[0]);
+                        
+                        let xCoord = coordinates[0];
+                        // Left/Center/Right
+                        if (xCoord.startsWith('L') || xCoord.startsWith('C') || xCoord.startsWith('R')) {
+                            anchorX = xCoord.charAt(0);
+                            xCoord = xCoord.substring(1);
+                        }
+                        if (xCoord.endsWith('px')) {
+                            pxX = parseInt(xCoord);
                             if (Number.isNaN(pxX)) {
                                 isValid = false;
                             }
                         } else {
-                            x = parseInt(coordinates[0]);
+                            x = parseInt(xCoord);
                             if (Number.isNaN(x)) {
                                 isValid = false;
                             }
                         }
 
-                        if (coordinates[1].endsWith('px')) {
-                            pxY = parseInt(coordinates[1]);
+                        let yCoord = coordinates[1];
+                        // Top/Center/Bottom
+                        if (yCoord.startsWith('T') || yCoord.startsWith('C') || yCoord.startsWith('B')) {
+                            anchorY = yCoord.charAt(0);
+                            yCoord = yCoord.substring(1);
+                        }
+                        if (yCoord.endsWith('px')) {
+                            pxY = parseInt(yCoord);
                             if (Number.isNaN(pxY)) {
                                 isValid = false;
                             }
                         } else {
-                            y = parseInt(coordinates[1]);
+                            y = parseInt(yCoord);
                             if (Number.isNaN(y)) {
                                 isValid = false;
                             }
@@ -355,7 +370,7 @@ SPECIAL_FILL-Fill
                         }
 
                         if (isValid) {
-                            layout.tiles.push({x: x, pxX: pxX, y: y, pxY: pxY, w: w, pxW: pxW, h: h, pxH: pxH});
+                            layout.tiles.push({x: x, pxX: pxX, y: y, pxY: pxY, w: w, pxW: pxW, h: h, pxH: pxH, anchorX: anchorX, anchorY: anchorY});
                         } else {
                             logE('Invalid user layout: ' + tiles[tileIndex]);
                         }


### PR DESCRIPTION
An anchoring system helps people like me who commonly switch resolutions depending on their workspace, especially when working remotely via an IPKVM, and people who want easier positioning relative to their screen.

To reiterate, Mouse Tiler accepts the `px,py,w,h` syntax for the Popup Mode, where:
`px` = X-axis/horizontal position
`py` = Y-axis/vertical position
`w` = width
`h` = height

All of those values are in percent unless the `px` (pixels) suffix is applied.

The `px` and `py` values currently assume that you are positioning the top left corner of the window at that position.
Should this PR be merged, px and py can optionally be prefixed with:
- in case of px: L, C or R for Left, Center or Right respectively
- in case of py: T, C or B for Top, Center or Bottom respectively

Examples:
50,50,w,h - top left, standard assumption
L50,T50,w,h - same thing
C50,C50,w,h - position window's center at screen center
R50,B50,w,h - position window's bottom right corner at screen center
C50,C50,1920px,1080px - position window center at screen center, resized to 1920x1080 (useful for webdevs with ultrawides)

The provided implementation should suffice.